### PR TITLE
add results from m3

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ and round to the tenths decimal place
 | Apple M1 Pro | 32 | 44.5 | 50.2 | 2025-02-15 | APFS (Encrypted) : APPLE SSD AP0512R 500GB | macOS 15.3 |
 | Apple M1 | 16 | 37.8 | 33.3 | 2025-02-19 | APFS (Encypted) : APPLE SSD AP0512Q 500GB | macOS 15.3.1 |
 | Apple M1 Pro | 16 | 59.4 | 69.1 | 2025-02-19 | APFS (Encrypted) : APPLE SSD AP1024R 1TB | macOS 14.7.3 |
+| Apple M3 | 16 | 36.23 | 30.3 | 2025-02-21 | APFS (Unencrypted) : APPLE SSD AP0256Z 256GB | macOS 15.3 |
 | Apple M4 Max (16 Cores) | 128 | 36.7 | 64.5 | 2025-02-20 | APFS (Encrypted) : APPLE SSD AP2048Z 2TB | macOS 15.2 |
 | Intel Core i7 14700K (20 Cores) | 64 | 3.1 | 13.8 | 2025-02-21 | Ext4 : WD Black 2TB SN850 | W10 22H2 / WSL2 / Ubuntu 24.04 |
 


### PR DESCRIPTION
m3 air if that matters

encrypted disk is just when FileVault is turned on, right?